### PR TITLE
Tidy up/mark dubious spaced curly quotes

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -9,6 +9,13 @@
 <span style="font-weight: bold;">Changelog History<br></span>
 <br>
 <br>
+<span style="font-weight: bold;"><big>Version .41d</big></span>
+(By windymilla):
+<ul>
+<li>Tidy up or mark dubious spaced <b>curly</b> quotes</li>
+<li>Fix spaced close single curly quotes (not mark as unknown) -
+leave unchecked if book has apostrophes at start of word, e.g. 'orrible</li>
+</ul>
 <span style="font-weight: bold;"><big>Version .41c</big></span>
 (By windymilla):
 <ul>

--- a/guiprep.html
+++ b/guiprep.html
@@ -149,6 +149,13 @@ built in that automates uploading a project to the site.<br>
 <hr style="width: 100%; height: 2px;"> <br>
 <span style="font-weight: bold;"><a name="Whats_new"></a><big>Whats new?</big></span><br>
 <br>
+<span style="font-weight: bold;"><big>Version .41d</big></span>
+(By windymilla):
+<ul>
+<li>Tidy up or mark dubious spaced <b>curly</b> quotes</li>
+<li>Fix spaced close single curly quotes (not mark as unknown) -
+leave unchecked if book has apostrophes at start of word, e.g. 'orrible</li>
+</ul>
 <span style="font-weight: bold;"><big>Version .41c</big></span>
 (By windymilla):
 <ul>


### PR DESCRIPTION
If files use curly quotes, then (unlike with straight quotes) if the quotes have spaces
before and after, it is generally possible to know which is the erroneous one.
Add an option to do this check and to correct or mark them - see below.

Only ambiguous case is single close quote. One of these with spaces before and
after could be a close quote with erroneous space before, but could also be an
apostrophe (e.g. dialect 'orrible) with erroneous space after. Second option switches
between fixing these (if CP knows there is no dialect) or just marking them as
suspect (the default)

Also updated changelog & manual.