### PR TITLE
Fix a couple of scroll issues

### DIFF
--- a/guiprep.pl
+++ b/guiprep.pl
@@ -602,8 +602,6 @@ my $p2o5 = $page2->Frame(-relief => 'groove', -borderwidth => 2
 my $p2opts = $p2o5->Scrolled('Pane', -scrollbars => 'e'
 )->pack(-side => 'top', -anchor => 'n', -fill => 'both', -expand => 'y', -pady=>'6',-padx =>'2');
 
-BindMouseWheel($p2opts);
-
 my $grow = 0;
 
 my $p2cb0 = $p2opts->Checkbutton(

--- a/guiprep.pl
+++ b/guiprep.pl
@@ -1310,7 +1310,7 @@ my $p4rframe =  $p4mframe->Frame()->pack(-side => 'left', -anchor => 'n', -expan
 
 my $dirbox = $p4rframe->Scrolled('Listbox',
 	-label => "Change To Directory:",
-	-scrollbars =>		'osoe',
+	-scrollbars =>		'ose',
 	-width =>		'35',
 	-height =>		'12',
 	-background =>		'white',
@@ -1322,7 +1322,7 @@ my $pdrframe =  $p4mframe->Frame()->pack(-side => 'right', -anchor => 'n', -expa
 
 $dirbox6 = $p4mframe->Scrolled('Listbox',
 	-label => "Select Directories To Batch Process: (Optional)",
-	-scrollbars =>		'osoe',
+	-scrollbars =>		'ose',
 	-width =>		'35',
 	-height =>		'12',
 	-background =>		'white',


### PR DESCRIPTION
1. Console error messages on Macs when using scroll wheel in bottom half of first tab.
2. Force vertical scroll bar to be visible when changing directory. 