### PR TITLE
Add optional scrollbar at bottom of Options tab

### DIFF
--- a/guiprep.pl
+++ b/guiprep.pl
@@ -599,7 +599,7 @@ my $batchremove = $p2o4->Checkbutton(
 my $p2o5 = $page2->Frame(-relief => 'groove', -borderwidth => 2
 )->pack(-side => 'top', -fill => 'both', -expand => 'y', -pady=>'4',-padx =>'2');
 
-my $p2opts = $p2o5->Scrolled('Pane', -scrollbars => 'e'
+my $p2opts = $p2o5->Scrolled('Pane', -scrollbars => 'ose'
 )->pack(-side => 'top', -anchor => 'n', -fill => 'both', -expand => 'y', -pady=>'6',-padx =>'2');
 
 my $grow = 0;

--- a/guiprep.pl
+++ b/guiprep.pl
@@ -540,7 +540,10 @@ my $supsclose = $p2o3->Entry(
 	  )->pack(-side => 'right', -anchor => 'ne');
 $supsclose->insert(0, $supclose);
 
-my $p2o4 = $page2->Frame(-relief => 'groove', -borderwidth => 2)->pack(-side => 'top', -fill => 'x', -pady => '2', -padx =>'2');
+my $p2o4f = $page2->Frame(-relief => 'groove', -borderwidth => 2)->pack(-side => 'top', -fill => 'x', -pady => '2', -padx =>'2');
+
+my $p2o4 = $p2o4f->Scrolled('Pane', -scrollbars => 'os'
+)->pack(-side => 'top', -anchor => 'n', -fill => 'both', -expand => 'y', -pady=>'6',-padx =>'2');
 
 my $p2cb23 = $p2o4->Checkbutton(
 	-variable => 	\$opt[23],


### PR DESCRIPTION
If window is narrow, options are truncated on the right.
Display scrollbar if options don't fit in window.